### PR TITLE
fix deprecated since symfony 4.2 tree builder

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,8 +10,10 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('unice_sil_shibboleth');
+        
+        $treeBuilder = new TreeBuilder('unice_sil_shibboleth');
+        // BC for symfony/config < 4.2
+        $rootNode = method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('unice_sil_shibboleth');
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ class Configuration implements ConfigurationInterface
         
         $treeBuilder = new TreeBuilder('unice_sil_shibboleth');
         // BC for symfony/config < 4.2
-        $rootNode = method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('unice_sil_shibboleth');
+        $rootNode = method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('unice_sil_shibboleth');
 
         $rootNode
             ->children()


### PR DESCRIPTION
 A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0